### PR TITLE
Create radiks User correctly on sign-in

### DIFF
--- a/radiks/src/components/App.js
+++ b/radiks/src/components/App.js
@@ -53,6 +53,7 @@ export default class App extends Component {
     const { userSession } = getConfig();
     if (userSession.isSignInPending()) {
       await userSession.handlePendingSignIn();
+      await User.createWithCurrentUser();
       window.location = '/';
     }
   }


### PR DESCRIPTION
This PR
* add a call to User.createWithCurrentUser();

It should be asyncronous, and it should not be in componentWillMount (deprecated)
