### PR TITLE
fix to actually log user in with radiks

### DIFF
--- a/radiks/src/components/App.js
+++ b/radiks/src/components/App.js
@@ -53,6 +53,7 @@ export default class App extends Component {
     const { userSession } = getConfig();
     if (userSession.isSignInPending()) {
       await userSession.handlePendingSignIn();
+      await User.createWithCurrentUser();
       window.location = '/';
     }
   }


### PR DESCRIPTION
While reviewing the Radiks bug reported from Stackit, I ran Stackit to try and debug the issue. It turns out that the user was never actually being logged in with Radiks. There was some code to call `await User.createWithCurrentUser()`, but that never actually ran. It was inside of a `handleSignIn` function that never got called. Blockstack auth did get called, however, in `App#componentWillMount`. So, I just added the Radiks sign in method there.

It's also the same fix from #7. You probably thought it wasn't right because that function was already written, but that block of code never actually runs.

After doing so, I was able to create a new Block, both with and without a collaborator. The home page doesn't actually have UI to display the Blocks, but I assume that's because you all were stuck on this issue.

N.B.: When inviting a user to a `UserGroup` in Radiks, the user has to have signed up for the app before you can invite them. This is a technical limitation, because Radiks needs their public key in order to encrypt an invitation for them.

I also recognize that error messages in Radiks are useless. I made an issue for that: https://github.com/blockstack/radiks/issues/52